### PR TITLE
Fix build script hanging issue

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -37,5 +37,6 @@ rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
       '  Tip: built files are meant to be served over an HTTP server.\n' +
       '  Opening index.html over file:// won\'t work.\n'
     ))
+    process.exit(0)
   })
 })


### PR DESCRIPTION
Add explicit process.exit(0) after successful build completion. This ensures the Node.js process exits cleanly and doesn't hang in CI/CD environments like GitHub Actions.